### PR TITLE
Add icons and forecast to weather widget

### DIFF
--- a/weather_widget.html
+++ b/weather_widget.html
@@ -5,16 +5,36 @@
 <title>ZuluAlpha Weather Widget</title>
 <style>
   body { font-family: Arial, sans-serif; margin: 0; padding: 10px; }
-  .weather-widget { max-width: 320px; border: 1px solid #ccc; padding: 10px; }
-  .weather-widget h2 { font-size: 1.2em; margin: 0 0 10px; }
+  .weather-widget { max-width: 360px; border: 1px solid #ccc; padding: 10px; border-radius: 8px; }
+  .current-btn {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 15px;
+    background: #f0f8ff;
+    border-radius: 8px;
+    margin-bottom: 10px;
+    font-size: 1.4em;
+    cursor: pointer;
+  }
+  .current-btn .icon {
+    font-size: 2em;
+    margin-right: 10px;
+  }
+  .weather-widget h2 { font-size: 1.2em; margin: 10px 0; }
   .weather-widget .value { font-weight: bold; }
+  .forecast { display: flex; gap: 6px; overflow-x: auto; margin-top: 10px; }
+  .forecast-day { flex: 1 0 40px; text-align: center; }
+  .forecast-day .icon { font-size: 1.2em; display: block; }
   iframe { width: 100%; border: none; height: 360px; }
 </style>
 </head>
 <body>
 <div class="weather-widget">
-  <h2>Current Weather</h2>
-  <div>Temperature: <span id="temperature" class="value"></span> °C</div>
+  <div id="current" class="current-btn">
+    <span class="icon" id="current-icon"></span>
+    <span id="temperature" class="value"></span>°C
+  </div>
   <div>Wind: <span id="wind" class="value"></span> km/h</div>
   <div>Humidity: <span id="humidity" class="value"></span>%</div>
   <div>Cloud Cover: <span id="cloud" class="value"></span>%</div>
@@ -22,13 +42,14 @@
   <div>Sunset: <span id="sunset" class="value"></span></div>
   <div>Moonrise: <span id="moonrise" class="value"></span></div>
   <div>Moonset: <span id="moonset" class="value"></span></div>
-  <div>Moon Phase: <span id="moonphase" class="value"></span></div>
+  <div>Moon Phase: <span id="moonphase-icon" class="icon"></span><span id="moonphase" class="value"></span></div>
   <div>Moon Illumination: <span id="moonillum" class="value"></span>%</div>
+  <div id="forecast" class="forecast"></div>
 </div>
 
 <h2>Radar (Southern Africa)</h2>
 <iframe
-  src="https://embed.windy.com/embed2.html?lat=-32.3587&lon=20.6203&zoom=4&level=surface&overlay=radar&product=radar&menu=&message=&marker=&calendar=now&pressure=&type=map&location=coordinates&detail=&detailLat=-32.3587&detailLon=20.6203&metricWind=default&metricTemp=default&radarRange=-1"
+  src="https://embed.windy.com/embed2.html?lat=-32.3587&lon=20.6203&zoom=4&level=surface&overlay=radar&product=radar&menu=&message=&marker=&calendar=now&pressure=&type=map&location=coordinates&detail=&detailLat=-32.3587&detailLon=20.6203&metricWind=default&metricTemp=default&radarRange=-1&play=1"
   allowfullscreen="allowfullscreen">
 </iframe>
 
@@ -38,18 +59,29 @@ const lat = -32.35871980906897;
 const lon = 20.62026635302537;
 
 function fetchWeather() {
-  const url = `https://api.open-meteo.com/v1/forecast?latitude=${lat}&longitude=${lon}&current_weather=true&hourly=relative_humidity_2m,cloudcover&timezone=auto`;
+  const url = `https://api.open-meteo.com/v1/forecast?latitude=${lat}&longitude=${lon}&current_weather=true&hourly=relative_humidity_2m,cloudcover&daily=weathercode,temperature_2m_max,temperature_2m_min&timezone=auto`;
   fetch(url)
     .then(resp => resp.json())
     .then(data => {
       const current = data.current_weather;
       document.getElementById('temperature').textContent = current.temperature;
       document.getElementById('wind').textContent = current.windspeed;
+      document.getElementById('current-icon').textContent = weatherIcon(current.weathercode);
 
       const idx = data.hourly.time.indexOf(current.time);
       if (idx >= 0) {
         document.getElementById('humidity').textContent = data.hourly.relative_humidity_2m[idx];
         document.getElementById('cloud').textContent = data.hourly.cloudcover[idx];
+      }
+
+      const fc = document.getElementById('forecast');
+      fc.innerHTML = '';
+      for (let i = 0; i < data.daily.time.length; i++) {
+        const day = new Date(data.daily.time[i]);
+        const div = document.createElement('div');
+        div.className = 'forecast-day';
+        div.innerHTML = `<span>${day.toLocaleDateString(undefined,{weekday:'short'})}</span><span class="icon">${weatherIcon(data.daily.weathercode[i])}</span><span>${Math.round(data.daily.temperature_2m_max[i])}°</span>`;
+        fc.appendChild(div);
       }
 
       const now = new Date(current.time);
@@ -67,6 +99,7 @@ function fetchWeather() {
       document.getElementById('moonset').textContent = fmt(moonTimes.set);
       document.getElementById('moonphase').textContent = moonPhaseName(moonIllum.phase);
       document.getElementById('moonillum').textContent = Math.round(moonIllum.fraction * 100);
+      document.getElementById('moonphase-icon').textContent = moonPhaseIcon(moonIllum.phase);
     })
     .catch(err => console.error('Weather fetch error:', err));
 }
@@ -75,6 +108,23 @@ function moonPhaseName(phase) {
   const p = phase * 8;
   const phases = ['New Moon', 'Waxing Crescent', 'First Quarter', 'Waxing Gibbous', 'Full Moon', 'Waning Gibbous', 'Last Quarter', 'Waning Crescent'];
   return phases[Math.round(p) % 8];
+}
+
+function moonPhaseIcon(phase) {
+  const icons = ['🌑','🌒','🌓','🌔','🌕','🌖','🌗','🌘'];
+  return icons[Math.round(phase*8) % 8];
+}
+
+function weatherIcon(code) {
+  if (code === 0) return '☀️';
+  if (code === 1) return '🌤️';
+  if (code === 2) return '⛅';
+  if (code === 3) return '☁️';
+  if (code === 45 || code === 48) return '🌫️';
+  if (code >= 51 && code <= 67) return '🌧️';
+  if (code >= 71 && code <= 86) return '❄️';
+  if (code >= 95) return '⛈️';
+  return '🌡️';
 }
 
 fetchWeather();


### PR DESCRIPTION
## Summary
- enhance weather widget design
- display current weather icon
- add moon phase icon
- show a 7‑day forecast with icons
- start radar animation automatically

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6877b2413bf8832cb6591346c79f1294