### PR TITLE
Center widget and radar widths

### DIFF
--- a/weather_widget.html
+++ b/weather_widget.html
@@ -5,7 +5,8 @@
 <title>ZuluAlpha Weather Widget</title>
 <style>
   body { font-family: Arial, sans-serif; margin: 0; padding: 10px; }
-  .weather-widget { max-width: 360px; border: 1px solid #ccc; padding: 10px; border-radius: 8px; }
+  .zaweather-container { max-width: 360px; width: 100%; margin: 0 auto; }
+  .weather-widget { width: 100%; border: 1px solid #ccc; padding: 10px; border-radius: 8px; box-sizing: border-box; }
   .current-btn {
     display: flex;
     align-items: center;
@@ -40,6 +41,7 @@
 </style>
 </head>
 <body>
+<div class="zaweather-container">
 <div class="weather-widget">
   <div id="current" class="current-btn">
     <span class="icon" id="current-icon"></span>
@@ -68,6 +70,7 @@
   src="https://embed.windy.com/embed2.html?lat=-32.3587&amp;lon=20.6203&amp;zoom=4&amp;level=surface&amp;overlay=clouds&amp;product=ecmwf&amp;menu=&amp;message=&amp;marker=&amp;calendar=now&amp;pressure=&amp;type=map&amp;location=coordinates&amp;detail=&amp;detailLat=-32.3587&amp;detailLon=20.6203&amp;metricWind=default&amp;metricTemp=default&amp;radarRange=-1&amp;play=1"
   allowfullscreen="allowfullscreen">
 </iframe>
+</div>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/suncalc/1.9.0/suncalc.min.js"></script>
 <script>

--- a/za-weather/css/zaweather.css
+++ b/za-weather/css/zaweather.css
@@ -1,8 +1,15 @@
-.weather-widget {
+.zaweather-container {
   max-width: 360px;
+  width: 100%;
+  margin: 0 auto;
+}
+
+.weather-widget {
+  width: 100%;
   border: 1px solid #ccc;
   padding: 10px;
   border-radius: 8px;
+  box-sizing: border-box;
 }
 .current-btn {
   display: flex;

--- a/za-weather/za-weather.php
+++ b/za-weather/za-weather.php
@@ -21,33 +21,35 @@ add_action( 'wp_enqueue_scripts', 'zaweather_enqueue_assets' );
 function zaweather_shortcode( $atts ) {
     ob_start();
     ?>
-    <div class="weather-widget">
-      <div id="current" class="current-btn">
-        <span class="icon" id="current-icon"></span>
-        <span id="temperature" class="value"></span>°C
-      </div>
-      <div class="live-table">
-        <div>
-          <div>Wind: <span id="wind" class="value"></span> km/h</div>
-          <div>Humidity: <span id="humidity" class="value"></span>%</div>
-          <div>Cloud Cover: <span id="cloud" class="value"></span>%</div>
-          <div>Sunrise: <span id="sunrise" class="value"></span></div>
-          <div>Sunset: <span id="sunset" class="value"></span></div>
+    <div class="zaweather-container">
+      <div class="weather-widget">
+        <div id="current" class="current-btn">
+          <span class="icon" id="current-icon"></span>
+          <span id="temperature" class="value"></span>°C
         </div>
-        <div>
-          <div>Moonrise: <span id="moonrise" class="value"></span></div>
-          <div>Moonset: <span id="moonset" class="value"></span></div>
-          <div>Moon Phase: <span id="moonphase-icon" class="icon"></span><span id="moonphase" class="value"></span></div>
-          <div>Moon Illumination: <span id="moonillum" class="value"></span>%</div>
+        <div class="live-table">
+          <div>
+            <div>Wind: <span id="wind" class="value"></span> km/h</div>
+            <div>Humidity: <span id="humidity" class="value"></span>%</div>
+            <div>Cloud Cover: <span id="cloud" class="value"></span>%</div>
+            <div>Sunrise: <span id="sunrise" class="value"></span></div>
+            <div>Sunset: <span id="sunset" class="value"></span></div>
+          </div>
+          <div>
+            <div>Moonrise: <span id="moonrise" class="value"></span></div>
+            <div>Moonset: <span id="moonset" class="value"></span></div>
+            <div>Moon Phase: <span id="moonphase-icon" class="icon"></span><span id="moonphase" class="value"></span></div>
+            <div>Moon Illumination: <span id="moonillum" class="value"></span>%</div>
+          </div>
         </div>
+        <div id="forecast" class="forecast"></div>
+        <div id="cloud-forecast" class="forecast cloud-forecast"></div>
       </div>
-      <div id="forecast" class="forecast"></div>
-      <div id="cloud-forecast" class="forecast cloud-forecast"></div>
-    </div>
 
-    <iframe
-      src="https://embed.windy.com/embed2.html?lat=-32.3587&lon=20.6203&zoom=4&level=surface&overlay=clouds&product=ecmwf&menu=&message=&marker=&calendar=now&pressure=&type=map&location=coordinates&detail=&detailLat=-32.3587&detailLon=20.6203&metricWind=default&metricTemp=default&radarRange=-1&play=1"
-      allowfullscreen="allowfullscreen"></iframe>
+      <iframe
+        src="https://embed.windy.com/embed2.html?lat=-32.3587&lon=20.6203&zoom=4&level=surface&overlay=clouds&product=ecmwf&menu=&message=&marker=&calendar=now&pressure=&type=map&location=coordinates&detail=&detailLat=-32.3587&detailLon=20.6203&metricWind=default&metricTemp=default&radarRange=-1&play=1"
+        allowfullscreen="allowfullscreen"></iframe>
+    </div>
     <?php
     return ob_get_clean();
 }


### PR DESCRIPTION
## Summary
- wrap widget and radar iframe in a new `.zaweather-container`
- give container a responsive width and let widget fill it
- update standalone HTML example

## Testing
- `php -l za-weather/za-weather.php`

------
https://chatgpt.com/codex/tasks/task_e_687e2f46ab70832c843097c0b1b1ed9f